### PR TITLE
Declare peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "bugs": {
     "url": "https://github.com/davidwebca/tailwindcss-group-variants/issues"
   },
-  "homepage": "https://github.com/davidwebca/tailwindcss-group-variants#readme"
+  "homepage": "https://github.com/davidwebca/tailwindcss-group-variants#readme",
+  "peerDependencies": {
+    "tailwindcss": "*",
+    "postcss-selector-parser": "*"
+  }
 }


### PR DESCRIPTION
Using Yarn 2 revealed this package use undeclared dependencies. This PR fixes it by adding the packaged as peer dependencies, since this package runs along with tailwindcss and its buddies.